### PR TITLE
fix:7-9期間での絞り込み機能

### DIFF
--- a/src/public/index.php
+++ b/src/public/index.php
@@ -7,19 +7,27 @@ $pdo = new PDO(
     $dbPassword
 );
 
+$params = [];
+$sql = "SELECT * FROM pages WHERE 1=1";
+
 if (isset($_GET['search'])) {
-  $name = '%' . $_GET["search"]. '%';
-  $contents = '%' . $_GET["search"]. '%';
-} else {
-  $name = '%%';
-  $contents = '%%';
+  $name = '%' . $_GET['search'] . '%';
+  $contents = '%' . $_GET['search'] . '%';
+  $sql .= ' AND (name LIKE :name OR contents LIKE :contents)';
+  $params[':name'] = $name;
+  $params[':contents'] = $contents;
 }
 
-$sql = 'SELECT * FROM pages WHERE name LIKE :name OR contents LIKE :contents';
+if (isset($_GET['start_date']) && isset($_GET['end_date'])) {
+  $start_date = $_GET['start_date'] . " 00:00:00";
+  $end_date = $_GET['end_date'] . " 23:59:59";
+  $sql .= ' AND (created_at BETWEEN :start_date AND :end_date)';
+  $params[':start_date'] = $start_date;
+  $params[':end_date'] = $end_date;
+}
+
 $statement = $pdo->prepare($sql);
-$statement->bindValue(':name', $name, PDO::PARAM_STR);
-$statement->bindValue(':contents', $contents, PDO::PARAM_STR);
-$statement->execute();
+$statement->execute($params);
 $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
 ?>
 
@@ -41,7 +49,7 @@ $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
             <input type="text" name="search"><br>
             <input type="submit">
       </form>
-      <form action="page.php" method="get">
+      <form action="mypage.php" method="get">
             <input type="date" name="start_date">
             <input type="date" name="end_date">
             <button type="submit">期間で絞り込む</button>

--- a/src/public/mypage.php
+++ b/src/public/mypage.php
@@ -7,14 +7,30 @@ $pdo = new PDO(
     $dbPassword
 );
 
-$sql = 'SELECT * FROM pages';
-$statement = $pdo->prepare($sql);
-$statement->bindValue(':title', $title, PDO::PARAM_STR);
-$statement->bindValue(':content', $content, PDO::PARAM_STR);
+$params = [];
+$sql = "SELECT * FROM pages WHERE 1=1";
 
-$statement->execute();
+if (isset($_GET['search'])) {
+  $name = '%' . $_GET['search'] . '%';
+  $contents = '%' . $_GET['search'] . '%';
+  $sql .= ' AND (name LIKE :name OR contents LIKE :contents)';
+  $params[':name'] = $name;
+  $params[':contents'] = $contents;
+}
+
+if (isset($_GET['start_date']) && isset($_GET['end_date'])) {
+  $start_date = $_GET['start_date'] . " 00:00:00";
+  $end_date = $_GET['end_date'] . " 23:59:59";
+  $sql .= ' AND (created_at BETWEEN :start_date AND :end_date)';
+  $params[':start_date'] = $start_date;
+  $params[':end_date'] = $end_date;
+}
+
+$statement = $pdo->prepare($sql);
+$statement->execute($params);
 $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
 ?>
+
 
 <!DOCTYPE html>
 <html lang="ja">
@@ -30,7 +46,7 @@ $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
   <div>
 
     <div>
-      <form action="index.php" method="get">
+      <form action="mypage.php" method="get">
         <div>
           <label>
             <input type="radio" name="order" value="desc" class="">
@@ -44,7 +60,7 @@ $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
         <button type="submit">送信</button>
       </form>
     </div>
-    
+
     <div>
       <table border="1">
         <tr>

--- a/src/public/page.php
+++ b/src/public/page.php
@@ -29,7 +29,6 @@ $statement->execute();
 $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
 ?>
 
-
 <!DOCTYPE html>
 <html lang="ja">
 


### PR DESCRIPTION
## 作業対象
[作業をした教材のURL]
https://www.notion.so/9-8456799c25874a85ba04b6962e9637c1

## 作業詳細
作成日で絞り込む機能をpage.phpに作成しましょう。

「検索ボタン」の押下時に、検索フォームに入力された期間の作成日のメモのみを表示する機能を作成しましょう。

例: 2022-04-12日~2022-04-13日に作成されたメモのみを表示

## 備考
index.phpとpage.phpの修正をしました。
ご確認宜しくお願いたします。
