### PR TITLE
fix:7-7新しい順、古い順での絞り込み実装

### DIFF
--- a/src/public/index.php
+++ b/src/public/index.php
@@ -7,15 +7,20 @@ $pdo = new PDO(
     $dbPassword
 );
 
+// 並び替えの順番を取得
+$order = $_GET['order'] ?? 'desc';
+$order = ($order === 'asc') ? 'asc' : 'desc';
+
+$name = '%%';
+$contents = '%%';
+
+// 検索機能
 if (isset($_GET['search'])) {
-  $name = '%' . $_GET["search"]. '%';
-  $contents = '%' . $_GET["search"]. '%';
-} else {
-  $name = '%%';
-  $contents = '%%';
+    $name = '%' . $_GET['search'] . '%';
+    $contents = '%' . $_GET['search'] . '%';
 }
 
-$sql = 'SELECT * FROM pages WHERE name LIKE :name OR contents LIKE :contents';
+$sql = "SELECT * FROM pages WHERE name LIKE :name OR contents LIKE :contents ORDER BY created_at $order";
 $statement = $pdo->prepare($sql);
 $statement->bindValue(':name', $name, PDO::PARAM_STR);
 $statement->bindValue(':contents', $contents, PDO::PARAM_STR);
@@ -40,7 +45,7 @@ $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
             <input type="text" name="search"><br>
             <input type="submit">
       </form>
-      <form action="index.php" method="get">
+      <form action="privatepage.php" method="get">
         <div>
           <label>
             <input type="radio" name="order" value="desc" class="">

--- a/src/public/page.php
+++ b/src/public/page.php
@@ -15,9 +15,9 @@ $statement->execute();
 $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
 ?>
 
+
 <!DOCTYPE html>
 <html lang="ja">
-
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/src/public/privatepage.php
+++ b/src/public/privatepage.php
@@ -7,14 +7,18 @@ $pdo = new PDO(
     $dbPassword
 );
 
-$sql = 'SELECT * FROM pages';
-$statement = $pdo->prepare($sql);
-$statement->bindValue(':title', $title, PDO::PARAM_STR);
-$statement->bindValue(':content', $content, PDO::PARAM_STR);
+// 並び替えの順番を取得
+$order = $_GET['order'] ?? 'desc'; // デフォルトを 'desc' に設定
+$order = ($order === 'asc') ? 'asc' : 'desc'; // それ以外は 'desc'
 
-$statement->execute();
+// SQLクエリ
+$sql = "SELECT * FROM pages ORDER BY  created_at $order";
+$statement = $pdo->query($sql);
+
 $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
+
 ?>
+
 
 <!DOCTYPE html>
 <html lang="ja">


### PR DESCRIPTION
## 作業対象
[作業をした教材のURL]
https://www.notion.so/7-4433cd8156b94365888be20ef7ed7b73

## 作業詳細
作成日の新しい順、古い順に並べ替えをする機能をprivatepage.phpに作成しましょう。

詳細は下記になります。

- [新しい順]を選択した場合は、作成日の新しい順で表示
- [古い順]を選択した場合は、作成日の古い順で表示
- どちらも選択されていない場合は、作成日の新しい順で表示

## 備考
index.phpとprivatepage.phpを修正しております。
ご確認宜しくお願い致します。
