### PR TITLE
fix:7-8日付での絞り込み

### DIFF
--- a/src/public/index.php
+++ b/src/public/index.php
@@ -40,6 +40,12 @@ $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
             <input type="text" name="search"><br>
             <input type="submit">
       </form>
+      <div>
+        <form action="top.php" method="GET">
+          <input type="date" name="date"><br>
+          <input type="submit" value="日付で検索">
+        </form>
+      </div>
       <form action="index.php" method="get">
         <div>
           <label>

--- a/src/public/page.php
+++ b/src/public/page.php
@@ -15,9 +15,9 @@ $statement->execute();
 $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
 ?>
 
+
 <!DOCTYPE html>
 <html lang="ja">
-
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/src/public/top.php
+++ b/src/public/top.php
@@ -40,7 +40,7 @@ $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
 <body>
   <div>
     <div>
-      <form action="index.php" method="get">
+      <form action="top.php" method="get">
         <div>
           <label>
             <input type="radio" name="order" value="desc" class="">

--- a/src/public/top.php
+++ b/src/public/top.php
@@ -8,12 +8,24 @@ $pdo = new PDO(
 );
 
 $sql = 'SELECT * FROM pages';
+$params = [];
+
+if (isset($_GET['date'])) {
+  $date = $_GET['date'];
+  $sql .= ' WHERE DATE(created_at) = :date';
+  $params[':date'] = $date;
+}
+
 $statement = $pdo->prepare($sql);
-$statement->bindValue(':title', $title, PDO::PARAM_STR);
-$statement->bindValue(':content', $content, PDO::PARAM_STR);
+
+foreach ($params as $key => $value) {
+  $statement->bindValue($key, $value, PDO::PARAM_STR);
+}
+
 $statement->execute();
 $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
 ?>
+
 
 <!DOCTYPE html>
 <html lang="ja">


### PR DESCRIPTION
## 作業対象
[作業をした教材のURL]
https://www.notion.so/8-9b4d63fcb44e466d922fe784f1c1dbbb

## 作業詳細
作成日で絞り込む機能をtop.phpに作成しましょう。

「検索ボタン」の押下時に、検索フォームに入力された日付の作成日のメモのみを表示する機能を作成しましょう。


## 備考
index.phpとtop.phpの修正をしているのでご確認宜しくお願い致します。

