### PR TITLE
fix:7−13絞り込み機能の練習⑧

### DIFF
--- a/src/public/index.php
+++ b/src/public/index.php
@@ -37,18 +37,12 @@ $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
 <body>
   <div>
     <div>
-      <form action="index.php" method="GET">
+      <form action="privatetop.php" method="GET">
             <input type="text" name="search"><br>
-            <input type="submit">
-      </form>
-      <form action="page.php" method="get">
             <input type="date" name="start_date">
             <input type="date" name="end_date">
-            <button type="submit">期間で絞り込む</button>
-      </form>
-      <form action="index.php" method="get">
-        <div>
-          <label>
+            <br>
+            <label>
             <input type="radio" name="order" value="desc" class="">
             <span>新着順</span>
           </label>
@@ -56,8 +50,8 @@ $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
             <input type="radio" name="order" value="asc" class="">
             <span>古い順</span>
           </label>
-        </div>
-        <button type="submit">送信</button>
+            <br>
+            <input type="submit">
       </form>
     </div>
 

--- a/src/public/privatetop.php
+++ b/src/public/privatetop.php
@@ -7,14 +7,33 @@ $pdo = new PDO(
     $dbPassword
 );
 
-$sql = 'SELECT * FROM pages';
+$search = $_GET['search'] ?? '';
+$start_date = $_GET['start_date'] ?? '';
+$end_date = $_GET['end_date'] ?? '';
+$order = $_GET['order'] ?? 'desc'; // 新着順がデフォルト
+
+$sql = "SELECT * FROM pages WHERE (name LIKE :search OR contents LIKE :search)";
+if (!empty($start_date)) {
+    $sql .= " AND created_at >= :start_date";
+}
+if (!empty($end_date)) {
+    $sql .= " AND created_at <= :end_date";
+}
+$sql .= " ORDER BY created_at " . $order;
+
 $statement = $pdo->prepare($sql);
-$statement->bindValue(':title', $title, PDO::PARAM_STR);
-$statement->bindValue(':content', $content, PDO::PARAM_STR);
+$statement->bindValue(':search', '%' . $search . '%', PDO::PARAM_STR);
+if (!empty($start_date)) {
+    $statement->bindValue(':start_date', $start_date . ' 00:00:00', PDO::PARAM_STR);
+}
+if (!empty($end_date)) {
+    $statement->bindValue(':end_date', $end_date . ' 23:59:59', PDO::PARAM_STR);
+}
 
 $statement->execute();
 $pages = $statement->fetchAll(PDO::FETCH_ASSOC);
 ?>
+
 
 <!DOCTYPE html>
 <html lang="ja">


### PR DESCRIPTION
## 作業対象
[作業をした教材のURL]
https://www.notion.so/13-ff0a56bd71194fcbaa2e28f22826991c

## 作業詳細
[作成日で絞り込む機能] かつ [検索ワードでの絞り込み] かつ [作成日の新しい順、古い順に並べ替え]をする機能をprivatetop.phpに作成しましょう。

例: 「検索ワードがメモのタイトルまたは内容に含まれる」かつ「作成日の新しい順」かつ「2022-04-13日に作成された」メモのみを表示。

例: 「検索ワードがメモのタイトルまたは内容に含まれる」かつ「作成日の古い順」かつ「2022-04-13日に作成された」メモのみを表示。
